### PR TITLE
hide file picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # bw-file-resubmit
 
-**bw-file-resubmit** is a drop-in replacement for [**django-file-resubmit**](https://github.com/un1t/django-file-resubmit), which appears to be abandoned.
+**bw-file-resubmit** is a drop-in replacement for [**django-file-resubmit**](https://github.com/un1t/django-file-resubmit), maintained by the BookWyrm project.
 
 In a Django project you may have forms using `FileField` or `ImageField`. Everything works great, but
 when a `ValidationError` is raised, or you want to add some other check before finally submitting the form, you have to reselect all files and images again. This is because HTML `<input type="file">` fields cannot be prepopulated with data due to basic browser security.
 
-**bw-file-resubmit** solves this problem by caching the file and adding it again in the background. It works with `FileField`, `ImageField` and `sorl.thumbnail.ImageField` (see [`sorl-thumbnail`](https://github.com/jazzband/sorl-thumbnail).
+**bw-file-resubmit** solves this problem by caching the file and adding it again in the background. It works with `FileField`, `ImageField` and `sorl.thumbnail.ImageField` (see [sorl-thumbnail](https://github.com/jazzband/sorl-thumbnail)).
 
 ## How does it work?
 
@@ -18,11 +18,9 @@ Special widgets can be used to replace `FileField` and `ImageField`. When you su
 
 ## Installation
 
-SOON
-
-<!-- ```sh
+```sh
 pip install bw-file-resubmit
-``` -->
+```
 
 ## Configuration
 
@@ -69,6 +67,9 @@ class Page(models.Model):
 ### Form widgets
 
 #### Ordinary form
+
+forms.py
+
 ```py
 from django.forms import ModelForm
 from file_resubmit.widgets import ResubmitImageWidget, ResubmitFileWidget
@@ -89,6 +90,11 @@ class Book(forms.Form):
 ```
 
 #### Admin form
+
+admin.py
+
+**NOTE:** `admin.AdminResubmitFileWidget` has been dropped from `bw-file-resubmit`. If you need to update a legacy `django-file-resubmit` project, use `widgets.ResubmitFileWidget` instead.
+
 ```py
 from django.forms import ModelForm
 from file_resubmit.admin import AdminResubmitImageWidget,
@@ -111,6 +117,8 @@ admin.site.register(Page, PageAdmin)
 ```
 
 ### Use as a model mixin in admin
+
+admin.py
 
 ```py
 from django.contrib import admin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "bw-file-resubmit"
-version = "0.6.0rc1"
+version = "0.6.0rc2"
 license = {text = "MIT License"}
 authors = [
-    { name="Ilya Shalyapin" },
+    { name="Ilya Shalyapin", email="ishalyapin@gmail.com"},
     { name="Hugh Rundle", email="hugh@hughrundle.net" }
 ]
 maintainers = [

--- a/src/file_resubmit/widgets.py
+++ b/src/file_resubmit/widgets.py
@@ -64,8 +64,11 @@ class ResubmitFileWidget(ResubmitBaseWidget):
         self, name, value, attrs=None, **kwargs
     ):  # pylint: disable=unused-argument
         """override render function to add hidden input"""
-        output = ClearableFileInput.render(self, name, value, attrs)
-        output += self.output_extra_data(value)
+        if self.cache_key:
+            output = self.output_extra_data(value)
+        else:
+            output = ClearableFileInput.render(self, name, value, attrs)
+            output += self.output_extra_data(value)
         return mark_safe(output)
 
 


### PR DESCRIPTION
Hide the file picker when a file has been retained in cache for 'resubmitting', to make it clearer that the file has been retained. Also updates README and RC version

Should resolve these issues from django-file-resubmit:

* https://github.com/un1t/django-file-resubmit/issues/21 
* https://github.com/un1t/django-file-resubmit/issues/22

and shortly...
* https://github.com/un1t/django-file-resubmit/issues/28